### PR TITLE
Merge 0.2.4

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,7 @@ bl_info = {
     'author': 'bonjorno7, TeamC',
     'description': 'A powerful saving tool',
     'blender': (2, 80, 0),
-    'version': (0, 2, 3),
+    'version': (0, 2, 4),
     'location': 'View3D',
     'wiki_url': 'https://github.com/bonjorno7/PowerSave',
     'category': '3D View'

--- a/addon/handlers/load_handler.py
+++ b/addon/handlers/load_handler.py
@@ -4,10 +4,12 @@ from .. import utils
 
 @bpy.app.handlers.persistent
 def load_handler(_):
+    utils.common.update_powersave_name()
     prefs = utils.common.prefs()
 
-    utils.common.update_powersave_name()
-
     if prefs.save_on_startup and not bpy.data.is_saved:
-        result = utils.save.powersave()
-        print(result[1])
+        bpy.ops.powersave.powersave()
+
+    if prefs.autosave_to_copy and bpy.data.is_saved:
+        if utils.save.should_load_autosave():
+            bpy.ops.powersave.load_autosave('INVOKE_DEFAULT')

--- a/addon/ops/__init__.py
+++ b/addon/ops/__init__.py
@@ -1,13 +1,16 @@
 import bpy
 from . import powersave
+from . import load_autosave
 from . import open_project_folder
 
 
 def register():
     bpy.utils.register_class(powersave.PowerSave)
+    bpy.utils.register_class(load_autosave.LoadAutosave)
     bpy.utils.register_class(open_project_folder.OpenProjectFolder)
 
 
 def unregister():
     bpy.utils.unregister_class(open_project_folder.OpenProjectFolder)
+    bpy.utils.unregister_class(load_autosave.LoadAutosave)
     bpy.utils.unregister_class(powersave.PowerSave)

--- a/addon/ops/load_autosave.py
+++ b/addon/ops/load_autosave.py
@@ -1,0 +1,24 @@
+import bpy
+from .. import utils
+
+
+class LoadAutosave(bpy.types.Operator):
+    bl_idname = 'powersave.load_autosave'
+    bl_label = 'Load Autosave'
+    bl_description = 'Load the autosave file for this blend'
+    bl_options = {'INTERNAL'}
+
+
+    def draw(self, context):
+        self.layout.label(text='The autosave file is newer, would you like to load it?')
+
+
+    def execute(self, context):
+        result = utils.save.load_autosave()
+        self.report(result[0], result[1])
+        return result[2]
+
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        return wm.invoke_props_dialog(self)

--- a/addon/props/prefs.py
+++ b/addon/props/prefs.py
@@ -26,6 +26,12 @@ class PowerSavePrefs(bpy.types.AddonPreferences):
         max=60,
     )
 
+    autosave_to_copy: bpy.props.BoolProperty(
+        name='Autosave to Copy',
+        description='Whether to autosave to a separate _autosave file',
+        default=False,
+    )
+
     save_on_startup: bpy.props.BoolProperty(
         name='Save on Startup',
         description='Whether to save new projects in your base folder automatically',
@@ -72,6 +78,7 @@ class PowerSavePrefs(bpy.types.AddonPreferences):
         utils.ui.draw_prop(layout, 'Base Folder', self, 'base_folder')
         utils.ui.draw_prop(layout, 'Use Autosave', self, 'use_autosave')
         utils.ui.draw_prop(layout, 'Autosave Interval', self, 'autosave_interval')
+        utils.ui.draw_prop(layout, 'Autosave to Copy', self, 'autosave_to_copy')
         utils.ui.draw_bool(layout, 'Save On Startup', self, 'save_on_startup')
         utils.ui.draw_prop(layout, 'Date Time Format', self, 'date_time_format')
         utils.ui.draw_prop(layout, 'Increment Format', self, 'increment_format')

--- a/addon/timers/autosave_timer.py
+++ b/addon/timers/autosave_timer.py
@@ -7,10 +7,10 @@ def autosave_timer():
     prefs = utils.common.prefs()
 
     if prefs.use_autosave and bpy.data.is_saved and bpy.data.is_dirty:
-        path = pathlib.Path(bpy.data.filepath)
+        path = utils.files.as_path(bpy.data.filepath)
 
         if prefs.autosave_to_copy:
-            path = path.with_suffix('.autosave')
+            path = utils.files.with_autosave(path)
 
         bpy.ops.wm.save_as_mainfile(filepath=str(path), check_existing=False, copy=True)
 

--- a/addon/timers/autosave_timer.py
+++ b/addon/timers/autosave_timer.py
@@ -1,4 +1,5 @@
 import bpy
+import pathlib
 from .. import utils
 
 
@@ -6,6 +7,11 @@ def autosave_timer():
     prefs = utils.common.prefs()
 
     if prefs.use_autosave and bpy.data.is_saved and bpy.data.is_dirty:
-        bpy.ops.wm.save_mainfile(check_existing=False)
+        path = pathlib.Path(bpy.data.filepath)
+
+        if prefs.autosave_to_copy:
+            path = path.with_suffix('.autosave')
+
+        bpy.ops.wm.save_as_mainfile(filepath=str(path), check_existing=False, copy=True)
 
     return prefs.autosave_interval * 60

--- a/addon/ui/main_panel.py
+++ b/addon/ui/main_panel.py
@@ -42,6 +42,7 @@ class PowerSavePanel(bpy.types.Panel):
         box = col.box().column()
         box.prop(prefs, 'use_autosave')
         box.prop(prefs, 'autosave_interval')
+        box.prop(prefs, 'autosave_to_copy')
         box.prop(prefs, 'save_on_startup')
 
 

--- a/addon/utils/files.py
+++ b/addon/utils/files.py
@@ -38,3 +38,12 @@ def open_project_folder():
         return ({'ERROR'}, 'Failed to open project folder', {'CANCELLED'})
 
     return ({'INFO'}, 'Opened project folder', {'FINISHED'})
+
+
+def as_path(path: str):
+    return pathlib.Path(path).resolve()
+
+
+def with_autosave(path: pathlib.Path):
+    stem = f'{path.stem}_autosave'
+    return path.with_name(f'{stem}{path.suffix}')

--- a/addon/utils/save.py
+++ b/addon/utils/save.py
@@ -65,3 +65,37 @@ def powersave():
         return ({'INFO'}, f'PowerSaved "{path.name}"', {'FINISHED'})
 
     return ({'WARNING'}, 'No PowerSave folder set', {'CANCELLED'})
+
+
+def should_load_autosave():
+    current_path = utils.files.as_path(bpy.data.filepath)
+    autosave_path = utils.files.with_autosave(current_path)
+
+    current_exists = current_path.is_file()
+    autosave_exists = autosave_path.is_file()
+    is_autosave = current_path.stem.endswith('_autosave')
+
+    if current_exists and autosave_exists and not is_autosave:
+        current_time = current_path.stat().st_mtime_ns
+        autosave_time = autosave_path.stat().st_mtime_ns
+        return autosave_time > current_time
+
+
+def load_autosave():
+    current_path = utils.files.as_path(bpy.data.filepath)
+    autosave_path = utils.files.with_autosave(current_path)
+
+    try:
+        bpy.ops.wm.open_mainfile(filepath=str(autosave_path))
+    except:
+        return ({'ERROR'}, f'Failed to load "{autosave_path.name}"', {'CANCELLED'})
+
+    new_path = increment_until_unique(current_path)
+
+    try:
+        bpy.ops.wm.save_as_mainfile(filepath=str(new_path))
+        utils.files.add_to_recent_files()
+    except:
+        return ({'ERROR'}, f'Failed to save "{new_path.name}"', {'CANCELLED'})
+
+    return ({'INFO'}, f'Loaded "{autosave_path.name}" as "{new_path.name}"', {'FINISHED'})

--- a/addon/utils/save.py
+++ b/addon/utils/save.py
@@ -60,8 +60,8 @@ def powersave():
             utils.files.add_to_recent_files()
 
         except:
-            return ({'ERROR'}, f'Failed to save "{path.name}"', {'CANCELLED'})
+            return ({'ERROR'}, f'Failed to PowerSave "{path.name}"', {'CANCELLED'})
 
-        return ({'INFO'}, f'Saved "{path.name}"', {'FINISHED'})
+        return ({'INFO'}, f'PowerSaved "{path.name}"', {'FINISHED'})
 
-    return ({'WARNING'}, 'No base folder set', {'CANCELLED'})
+    return ({'WARNING'}, 'No PowerSave folder set', {'CANCELLED'})

--- a/addon/utils/save.py
+++ b/addon/utils/save.py
@@ -56,7 +56,7 @@ def powersave():
 
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            bpy.ops.wm.save_mainfile(filepath=str(path))
+            bpy.ops.wm.save_as_mainfile(filepath=str(path))
             utils.files.add_to_recent_files()
 
         except:


### PR DESCRIPTION
File name sanitization now uses a blacklist of invalid characters instead of a whitelist of valid characters, so you can use any file name you want.
I've also implemented autosaving to a separate file, and asking the user whether they want to load that file (with the name of the original file but incremented).