### PR TITLE
Merge 0.2.6

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,7 @@ bl_info = {
     'author': 'bonjorno7, TeamC',
     'description': 'A powerful saving tool',
     'blender': (2, 80, 0),
-    'version': (0, 2, 5),
+    'version': (0, 2, 6),
     'location': 'View3D',
     'wiki_url': 'https://github.com/bonjorno7/PowerSave',
     'category': '3D View'

--- a/addon/props/prefs.py
+++ b/addon/props/prefs.py
@@ -77,14 +77,14 @@ class PowerSavePrefs(bpy.types.AddonPreferences):
         layout = self.layout
 
         utils.ui.draw_prop(layout, 'Base Folder', self, 'base_folder')
-        utils.ui.draw_prop(layout, 'Use Autosave', self, 'use_autosave')
         utils.ui.draw_prop(layout, 'Autosave Interval', self, 'autosave_interval')
+        utils.ui.draw_prop(layout, 'Use Autosave', self, 'use_autosave')
         utils.ui.draw_prop(layout, 'Autosave to Copy', self, 'autosave_to_copy')
         utils.ui.draw_bool(layout, 'Save On Startup', self, 'save_on_startup')
         utils.ui.draw_prop(layout, 'Date Time Format', self, 'date_time_format')
         utils.ui.draw_prop(layout, 'Increment Format', self, 'increment_format')
-        utils.ui.draw_prop(layout, 'High Contrast Icons', self, 'high_contrast_icons')
         utils.ui.draw_prop(layout, 'Panel Category', self, 'panel_category')
+        utils.ui.draw_prop(layout, 'High Contrast Icons', self, 'high_contrast_icons')
 
         url = 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes'
         utils.ui.draw_op(layout, 'Date Time Documentation', 'wm.url_open', {'url': url})

--- a/addon/props/prefs.py
+++ b/addon/props/prefs.py
@@ -10,6 +10,7 @@ class PowerSavePrefs(bpy.types.AddonPreferences):
         description='The directory where initial saves will be stored',
         default=utils.files.get_default_folder(),
         subtype='FILE_PATH',
+        update=utils.common.update_base_folder,
     )
 
     use_autosave: bpy.props.BoolProperty(

--- a/addon/ui/main_panel.py
+++ b/addon/ui/main_panel.py
@@ -43,8 +43,10 @@ class PowerSavePanel(bpy.types.Panel):
         col.separator()
 
         box = col.box().column()
+        row = box.row()
+        row.enabled = prefs.use_autosave
+        row.prop(prefs, 'autosave_interval')
         box.prop(prefs, 'use_autosave')
-        box.prop(prefs, 'autosave_interval')
         box.prop(prefs, 'autosave_to_copy')
         box.prop(prefs, 'save_on_startup')
 

--- a/addon/utils/common.py
+++ b/addon/utils/common.py
@@ -3,6 +3,7 @@ import datetime
 import re
 import pathlib
 from .. import props
+from .. import utils
 from .. import ui
 
 
@@ -36,6 +37,16 @@ def increment():
 
 def date_time_increment():
     return f'{date_time()}{increment()}'
+
+
+def update_base_folder(self, context):
+    folder = utils.files.as_path(self['base_folder'])
+    parent = folder.parent
+
+    if folder.name == parent.name:
+        folder = parent
+
+    self['base_folder'] = str(folder)
 
 
 def update_powersave_name():

--- a/addon/utils/save.py
+++ b/addon/utils/save.py
@@ -25,6 +25,9 @@ def powersave():
     else:
         path = pathlib.Path(prefs.base_folder)
 
+    if bpy.data.is_saved and not prefs.powersave_name:
+        utils.common.update_powersave_name()
+
     if prefs.powersave_name:
         name = prefs.powersave_name
     else:


### PR DESCRIPTION
When the addon is just installed, the powersave name isn't set, because of restrictions. This can lead to accidently doing a datetime save instead of an incremental save. Fixed now by doing a check for it in the powersave function.
Also fixed an issue with the base folder file browser, which you can read about in the commit description.
And lastly I changed the order of items in preferences, and gray out autosave interval when autosave is disabled in the panel.